### PR TITLE
Add per-product handlers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the logger
     env_logger::init();
 
+    // Create websocket client 
     let ws_cli = CoinbaseWebSocketClient::new();
-    
+
+    // Register handler for BTC
     ws_cli.register_handler(
         "BTC-USD".to_string(),
         |msg: Ticker| {	    
@@ -21,5 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     ).await;
 
+    // Connect and listen to the websocket where the callback
+    // handler will be run for each message 
     return ws_cli.connect_and_listen().await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,25 @@
 use coinbase_websocket::websocket::client::CoinbaseWebSocketClient;
+use coinbase_websocket::models::ticker::Ticker;
+
+use log::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the logger
     env_logger::init();
+
+    let ws_cli = CoinbaseWebSocketClient::new();
     
-    // Connect and start listening for messages
-    CoinbaseWebSocketClient::connect_and_listen().await
+    ws_cli.register_handler(
+        "BTC-USD".to_string(),
+        |msg: Ticker| {	    
+            info!(
+                "BTC-USD Handler: Current price of {} is {}",
+		msg.ticker_type,
+                msg.price
+            );
+        },
+    ).await;
+
+    return ws_cli.connect_and_listen().await;
 }

--- a/src/models/ticker.rs
+++ b/src/models/ticker.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Represents the complete WebSocket message from Coinbase
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WebSocketMessage {
     /// The channel name (e.g., "ticker")
     pub channel: String,
@@ -17,7 +17,7 @@ pub struct WebSocketMessage {
 }
 
 /// Represents an event within the WebSocket message
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Event {
     /// Array of ticker updates
     pub tickers: Vec<Ticker>,
@@ -27,7 +27,7 @@ pub struct Event {
 }
 
 /// Contains the actual ticker data for a cryptocurrency
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Ticker {
     /// Best asking price in USD
     pub best_ask: String,

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -2,41 +2,89 @@ use futures_util::{SinkExt, StreamExt};
 use log::{debug, error, info, warn};
 use serde_json::json;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-use crate::models::ticker::WebSocketMessage;
 
-pub const WS_URL: &str = "wss://advanced-trade-ws.coinbase.com";
+use crate::models::ticker::{WebSocketMessage, Ticker};
+
+const WS_URL: &str = "wss://advanced-trade-ws.coinbase.com";
+
+// Type alias for our handler function
+pub type MessageHandler = Arc<dyn Fn(Ticker) + Send + Sync>;
 
 /// Interface to coinbase 'advanced trade' websocket
-pub struct CoinbaseWebSocketClient;
+pub struct CoinbaseWebSocketClient {
+    // Store handlers in a thread-safe map that can be shared across async tasks
+    handlers: Arc<RwLock<HashMap<String, MessageHandler>>>,
+}
+
 
 impl CoinbaseWebSocketClient {
-    pub fn handle_ws_msg(msg: WebSocketMessage) {
-        debug!("Got new message from ws @ {}", msg.timestamp);
-        info!(
-            "Current value of BTC-USD is {}",
-            msg.events[0].tickers[0].price
-        );
+    pub fn new() -> Self {
+        Self {
+            handlers: Arc::new(RwLock::new(HashMap::new())),
+        }
     }
 
-    pub async fn connect_and_listen() -> Result<(), Box<dyn std::error::Error>> {
+    /// Method to register a handler for a specific product ID
+    pub async fn register_handler<F>(&self, product_id: String, handler: F)
+    where
+        F: Fn(Ticker) + Send + Sync + 'static,
+    {
+	info!("Adding handler for product ID {}", product_id);
+        let mut handlers = self.handlers.write().await;
+        handlers.insert(product_id, Arc::new(handler));
+    }
+
+    async fn dispatch_message(
+        &self,
+        message: WebSocketMessage,
+    ) {
+        // Get a read lock on the handlers map
+        let handlers = self.handlers.read().await;
+        
+        // For each ticker in the message
+        for event in &message.events {
+            for ticker in &event.tickers {
+                // If we have a handler for this product ID, call it
+                if let Some(handler) = handlers.get(&ticker.product_id) {
+                    handler(ticker.clone());
+                }
+            }
+        }
+    }
+
+
+    pub async fn connect_and_listen(&self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Connecting to coinbase websocket");
         
-        // Connect to the WebSocket server
+        // Create the subscription message
+        let handlers = self.handlers.read().await;
+        let product_ids: Vec<String> = handlers.keys().cloned().collect();
+        
+        // Ensure we have at least one handler registered
+        if product_ids.is_empty() {
+            return Err("No handlers registered. Please register at least one handler before connecting.".into());
+        }
+        
+        debug!("Found handlers for products: {:?}", product_ids);
+	
+        let subscribe_msg = json!({
+            "type": "subscribe",
+            "product_ids": product_ids,
+            "channel": "ticker"
+        });
+        info!("Subscribing to {}", subscribe_msg);
+
+	// Connect to the WebSocket server
         debug!("Connecting to websocket {}", WS_URL);
         let (ws_stream, _) = connect_async(WS_URL).await?;
         info!("Connected to Coinbase WebSocket server");
         
         // Split the WebSocket stream into sender and receiver
         let (mut write, mut read) = ws_stream.split();
-        
-        // Create the subscription message
-        let subscribe_msg = json!({
-            "type": "subscribe",
-            "product_ids": ["BTC-USD"],
-            "channel": "ticker"
-        });
-        debug!("Subscribing to {}", subscribe_msg);
         
         // Send the subscription message
         write.send(Message::Text(subscribe_msg.to_string())).await?;
@@ -46,9 +94,10 @@ impl CoinbaseWebSocketClient {
             match message_result {
                 Ok(message) => match message {
                     Message::Text(text) => {
+			debug!("Received JSON message from websocket {}", text);
                         // Parse the JSON message
                         match serde_json::from_str::<WebSocketMessage>(&text) {
-                            Ok(data) => Self::handle_ws_msg(data),
+                            Ok(data) => self.dispatch_message(data).await,
                             Err(e) => error!("Failed to parse message '{}': {}", text, e),
                         }
                     }

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -66,7 +66,8 @@ impl CoinbaseWebSocketClient {
         
         // Ensure we have at least one handler registered
         if product_ids.is_empty() {
-            return Err("No handlers registered. Please register at least one handler before connecting.".into());
+            return Err("No handlers registered. \
+			Please register at least one handler before connecting.".into());
         }
         
         debug!("Found handlers for products: {:?}", product_ids);
@@ -111,7 +112,7 @@ impl CoinbaseWebSocketClient {
                 },
                 Err(e) => {
                     error!("Error receiving message: {}", e);
-                    break;
+                    return Err(e.into())
                 }
             }
         }


### PR DESCRIPTION
Added per-product handlers that can be configured like 

```rust
    // Create websocket client 
    let ws_cli = CoinbaseWebSocketClient::new();

    // Register handler for BTC
    ws_cli.register_handler(
        "BTC-USD".to_string(),
        |msg: Ticker| {	    
            info!(
                "BTC-USD Handler: Current price of {} is {}",
		msg.ticker_type,
                msg.price
            );
        },
    ).await;
```

where each message will dispatch to the appropriate handler method. 